### PR TITLE
Remove quoting method that was leading to double-quoted labels

### DIFF
--- a/islandoraUtils/fedoraLib.py
+++ b/islandoraUtils/fedoraLib.py
@@ -110,7 +110,7 @@ def update_datastream(obj, dsid, filename, label='', mimeType='', controlGroup='
         'url': conn.url,
         'username': conn.username, 'password': conn.password,
         'pid': obj.pid, 'dsid': dsid,
-        'label': quote(label), 'mimetype': mimeType, 'controlgroup': controlGroup,
+        'label': label, 'mimetype': mimeType, 'controlgroup': controlGroup,
         'filename': filename,
         'tries': tries,
         'checksumType': checksumType,


### PR DESCRIPTION
Double-quoted labels were being inserted into the Repo:

![quoting_bug_before](https://f.cloud.github.com/assets/244894/683554/3d85f1dc-d9e2-11e2-97ed-3381204d1f77.png)
![quoting_bug_before_fedora](https://f.cloud.github.com/assets/244894/683557/47f3632a-d9e2-11e2-8ffb-ce448bdc6cec.png)

Removing the quote method:

![quoting_bug_after](https://f.cloud.github.com/assets/244894/683561/5d6c06da-d9e2-11e2-80aa-d4337f949c07.png)
